### PR TITLE
Fix name in apps.py and update version

### DIFF
--- a/django_dictiterators/apps.py
+++ b/django_dictiterators/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
 
 
-class DjangoTemplateIteratorsConfig(AppConfig):
-    name = 'django_template_iterators'
+class DjangoDictIteratorsConfig(AppConfig):
+    name = 'django_dictiterators'

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='django-dictiterators',
-    version='1.1.0',
+    version='1.1.1',
     description='Django utility to work with list of dicts in templates',
     long_description=long_description,
     keywords='django templates',
-    url='https://github.com/Aalto-LeTech/django-dictiterators',
+    url='https://github.com/apluslms/django-dictiterators',
     author='Jaakko Kantojärvi',
     author_email='jaakko@n-1.fi',
     license='MIT',
@@ -42,11 +42,12 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Framework :: Django',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 3.2',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
     ],
 
@@ -54,6 +55,6 @@ setup(
     include_package_data = True,
 
     install_requires=[
-        'Django >=1.9.7',
+        'Django >= 3.2',
     ],
 )


### PR DESCRIPTION
# Description

**What?**

Change the name in ``apps.py`` to match the app's name.

**Why?**

The old name was causing an error when upgrading MOOC-Jutut to use Django 3.2.
It has to match the app's name.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that changing the name fixed the error that I was facing with Django 3.2.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [x] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
